### PR TITLE
Set `scriptLoaded` if `window.hbspt`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 
 let globalId = 0
-let scriptLoaded = false
+let scriptLoaded = Boolean(window.hbspt)
 
 export default class HubspotForm extends React.Component {
 	constructor(props) {


### PR DESCRIPTION
If `window.hbspt` is already available, assume the hubspot script was just loaded somewhere else.