### PR TITLE
onSubmit fix & onReady

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ import HubspotForm from 'react-hubspot-form'
    portalId='your_portal_id'
    formId='your_form_id'
    onSubmit={() => console.log('Submit!')}
+   onReady={(form) => console.log('Form ready!')}
    loading={<div>Loading...</div>}
    />
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ class HubspotForm extends React.Component {
 			}
 			delete props.loading
 			delete props.onSubmit
+			delete props.onReady
 			let options = {
 				...props,
 				target: `#${this.el.getAttribute(`id`)}`,
@@ -51,9 +52,10 @@ class HubspotForm extends React.Component {
 		}
 	}
 	onSubmit(){
-		let interval = setInterval(() => {
+		clearInterval(this.onSubmitInterval)
+		this.onSubmitInterval = setInterval(() => {
 			if(!this.el.querySelector(`form`)){
-				clearInterval(interval)
+				clearInterval(this.onSubmitInterval)
 				if(this.props.onSubmit){
 					this.props.onSubmit()
 				}
@@ -64,6 +66,14 @@ class HubspotForm extends React.Component {
 		this.loadScript()
 		this.createForm()
 		this.findFormElement()
+	}
+	componentWillUnmount() {
+		clearInterval(this.onSubmitInterval)
+	}
+	componentDidUpdate(prevProps, prevState) {
+		if (this.state.loaded && !prevState.loaded && this.props.onReady) {
+			this.props.onReady(this.el);
+		}
 	}
 	render() {
 		return (

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,9 @@ class HubspotForm extends React.Component {
 		if(form){
 			this.setState({ loaded: true })
 			form.addEventListener(`submit`, this.onSubmit)
+			if (this.props.onReady) {
+				this.props.onReady(form);
+			}
 		}
 		else{
 			setTimeout(this.findFormElement, 1)
@@ -69,11 +72,6 @@ class HubspotForm extends React.Component {
 	}
 	componentWillUnmount() {
 		clearInterval(this.onSubmitInterval)
-	}
-	componentDidUpdate(prevProps, prevState) {
-		if (this.state.loaded && !prevState.loaded && this.props.onReady) {
-			this.props.onReady(this.el);
-		}
 	}
 	render() {
 		return (


### PR DESCRIPTION
Hello! Thanks for making this Hubspot form component! I made two small changes that helped me, so I thought I'd contribute them back.

### 1. `onSubmit` fix

Your component's `onSubmit` handler is useful when you can't use Hubspot's own `onFormSubmit` on a page without jQuery. However, I encountered a small bug.

The `onSubmit` method on the component is triggered off the form element's submit event when the user first clicks submit. A function runs every tick until the form element is removed from the page. When the form element is gone, the component knows that Hubspot has validated the form and collected the data, so it's time to run the `onSubmit` prop passed to the component.

The issue I was having is occurs when someone first fails validation but later succeeds. When a user submits the form twice (or more), there are multiple intervals started in the component's `onSubmit` method. The problem here is that once the form eventually disappears all of the looping `onSubmit` handlers get called.

The first time my `onSubmit` prop was called, it removed the Hubspot form from the page. The later `onSubmit` component method calls fail on line 60 (in this PR's version of the code) because `this.el` is null.

My fix had two small pieces:
* `clearInterval` before calling `setInterval` again. This prevents multiple calls. 
* `clearInterval` before unmounting the component. This doesn't solve any direct problem, but I feel like it's better to be tidy.

### 2. `onReady`

The Hubspot library provides an option to know when the form is added to the DOM, aptly called `onFormReady`. Much like `onFormSubmit`, `onFormReady` requires jQuery loaded on the page. Given that, I thought it'd be helpful for this component to accept an `onReady` prop like its `onSubmit` one.

My specific use case for this prop was to fill in a hidden email field if it's available. Though, I imagine there are many times you'd want access to the form after its added to the page.

