### PR TITLE
Protect against fast unmounting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,10 @@ class HubspotForm extends React.Component {
 	}
 	createForm() {
 		if (window.hbspt) {
+			// protect against component unmounting before window.hbspt is available
+			if (this.el === null) {
+				return;
+			}
 			let props = {
 				...this.props
 			}
@@ -42,6 +46,10 @@ class HubspotForm extends React.Component {
 		document.head.appendChild(script)
 	}
 	findFormElement(){
+		// protect against component unmounting before form is added
+		if (this.el === null) {
+			return;
+		}
 		let form = this.el.querySelector(`form`)
 		if(form){
 			this.setState({ loaded: true })


### PR DESCRIPTION
#### The Problem

I was seeing crashes in both `findFormElement` and `createForm` when the component was unmounted right after being added to the page. While both of these are initially called from `componentDidMount` (when we definitely can access `this.el`), both methods reschedule themselves until some condition is met (`<form>` appearing and `window.hbspt` being defined respectively). It's possible that the component is unmounted before those conditions are met.

#### The Fix

Check if `this.el` is `null` and exit if so. This is safe because unmounting calls the ref callback with `null`:

> React will call the ref callback with the DOM element when the component mounts, and call it with null when it unmounts.

https://reactjs.org/docs/refs-and-the-dom.html