### PR TITLE
Fix to endless forms loading

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ class HubspotForm extends React.Component {
 		if (this.el === null) {
 			return
 		}
-		let form = this.el.querySelector(`form`)
+		let form = this.el.querySelector(`iframe`)
 		if(form){
 			this.setState({ loaded: true })
 			form.addEventListener(`submit`, this.onSubmit)


### PR DESCRIPTION
Seems HS has modified their Forms to use IFRAMES instead of embedded forms. Not sure if it's an account issue, but this fixes the issue for us.