### PR TITLE
Defer Hubspot script loading

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,13 @@ class HubspotForm extends React.Component {
 		if(scriptLoaded || this.props.noScript) return
 		scriptLoaded = true
 		let script = document.createElement(`script`)
+    script.defer = true
+
+    script.onload = () => {
+      this.createForm()
+      this.findFormElement()
+    }
+
 		script.src = `//js.hsforms.net/forms/v2.js`
 		document.head.appendChild(script)
 	}
@@ -75,8 +82,6 @@ class HubspotForm extends React.Component {
 	}
 	componentDidMount() {
 		this.loadScript()
-		this.createForm()
-		this.findFormElement()
 	}
 	componentWillUnmount() {
 		clearInterval(this.onSubmitInterval)


### PR DESCRIPTION
This is intended to fix a performance issue we've been experiencing on [gatsbyjs.org](https://www.gatsbyjs.org) and [gatsbyjs.com](https://www.gatsbyjs.com) - the HubSpot JS is blocking the rest of the page from loading.